### PR TITLE
fix missing ids in schema

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Database
 
 [options]
@@ -39,7 +40,6 @@ install_requires =
 
 [options.packages.find]
 where = src
-
 
 [options.package_data]
 psqlgml =

--- a/src/psqlgml/dictionaries/schemas.py
+++ b/src/psqlgml/dictionaries/schemas.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, FrozenSet, List, Optional, Set, TypeVar, cast
@@ -21,11 +20,7 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_META_SCHEMA: typings.Final[str] = "metaschema.yaml"
 DEFAULT_DEFINITIONS: FrozenSet[str] = frozenset(
-    [
-        "_definitions.yaml",
-        "_terms.yaml",
-        "_terms_enum.yaml",
-    ]
+    ["_definitions.yaml", "_terms.yaml", "_terms_enum.yaml", "_settings.yaml"]
 )
 
 T = TypeVar("T")
@@ -194,6 +189,10 @@ def resolve_ref(reference: str, resolver: Optional[Resolver] = None) -> Any:
 def _load_schema(schemas: List[types.DictionarySchemaDict]) -> Dict[str, DictionarySchema]:
     loaded: Dict[str, DictionarySchema] = {}
     for schema in schemas:
+        if "id" not in schema:
+            logger.info("Skipping definition without an id entry")
+            continue
+
         logger.debug(f"Resolving dictionary schema with id: {schema['id']}")
 
         raw: types.DictionarySchemaDict = resolve_schema(schema)

--- a/tests/unit/test_git_repository.py
+++ b/tests/unit/test_git_repository.py
@@ -42,7 +42,7 @@ def test_get_local_git_dir(local_git_home: str) -> None:
 
         repo = repository.GitRepository(name="dictionary", url=REMOTE_GIT_URL, lazy_load=True)
         assert repo.name == "dictionary"
-        assert Path(f"{local_git_home}/dictionary") == repo.local_directory
+        assert Path(f"{local_git_home}/dictionary/master") == repo.local_directory
 
 
 def test_lazy_load_no_clone(tmpdir: Path) -> None:


### PR DESCRIPTION
Skip schemas without ids, since this is crucial for naming entries, checkout each version to different directories to avoid mismatches and conflicts